### PR TITLE
change package import to context (Go1.9)

### DIFF
--- a/src/caterpillar/api.go
+++ b/src/caterpillar/api.go
@@ -1,6 +1,7 @@
 package caterpillar
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -15,7 +16,6 @@ import (
 	"github.com/knightso/base/errors"
 	"github.com/knightso/base/gae/ds"
 	"github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/delay"

--- a/src/caterpillar/caterpillar.go
+++ b/src/caterpillar/caterpillar.go
@@ -3,6 +3,7 @@ package caterpillar
 import (
 	"caterpillar/common"
 	"caterpillar/model"
+	"context"
 	"fmt"
 	"html/template"
 	"io/ioutil"
@@ -19,7 +20,6 @@ import (
 	"github.com/go-martini/martini"
 	"github.com/knightso/base/errors"
 	"github.com/knightso/base/gae/ds"
-	"golang.org/x/net/context"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 	applog "google.golang.org/appengine/log"

--- a/src/caterpillar/caterpillar_test.go
+++ b/src/caterpillar/caterpillar_test.go
@@ -9,11 +9,11 @@ import (
 
 //func parseWormhole(s string) (*Wormhole, string) {
 func TestParseWormhole1(t *testing.T) {
-	c, err := aetest.NewContext(nil)
+	_, done, err := aetest.NewContext()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close()
+	defer done()
 
 	wh, rpl := parseWormhole(`[[hoge]]`)
 	if wh == nil {
@@ -35,11 +35,11 @@ func TestParseWormhole1(t *testing.T) {
 }
 
 func TestParseWormhole2(t *testing.T) {
-	c, err := aetest.NewContext(nil)
+	_, done, err := aetest.NewContext()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close()
+	defer done()
 
 	wh, rpl := parseWormhole(`[[.Moke  もけ]]`)
 	if wh == nil {

--- a/src/caterpillar/filemanager/datastore.go
+++ b/src/caterpillar/filemanager/datastore.go
@@ -1,12 +1,12 @@
 package filemanager
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 
 	"github.com/knightso/base/gae/ds"
-	"golang.org/x/net/context"
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/log"
 )

--- a/src/caterpillar/filemanager/gcs.go
+++ b/src/caterpillar/filemanager/gcs.go
@@ -1,11 +1,11 @@
 package filemanager
 
 import (
+	"context"
 	"fmt"
 
 	"cloud.google.com/go/storage"
 	"github.com/knightso/base/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/appengine/file"
 	"google.golang.org/appengine/log"
 )

--- a/src/caterpillar/filemanager/serve.go
+++ b/src/caterpillar/filemanager/serve.go
@@ -1,9 +1,9 @@
 package filemanager
 
 import (
+	"context"
 	"net/url"
 
-	"golang.org/x/net/context"
 	"google.golang.org/appengine/blobstore"
 	"google.golang.org/appengine/image"
 	"google.golang.org/appengine/log"

--- a/src/caterpillar/model/models.go
+++ b/src/caterpillar/model/models.go
@@ -2,11 +2,11 @@ package model
 
 import (
 	"caterpillar/common"
+	"context"
 	"strconv"
 	"strings"
 
 	"github.com/knightso/base/gae/ds"
-	"golang.org/x/net/context"
 	"google.golang.org/appengine/datastore"
 )
 


### PR DESCRIPTION
- change package import from golang.org/x/net/context to context
- fix usage of astest.NewContext
- verified by Google Cloud SDK 210.0.0 (api_version: go1.9)
- ignore golint or go vet error