### PR TITLE
fix: Uncaught TypeError: Cannot read property 'addEventListener' of null at tinymce_init.js

### DIFF
--- a/src/caterpillar/static/tinymce_init.js
+++ b/src/caterpillar/static/tinymce_init.js
@@ -88,6 +88,10 @@
 	// W3C DOCイベントモデルサポートブラウザのみ対応 FireFox, Chrome, Safari, Opera, IE9 ～
 	window.addEventListener('load', function() {
 		var submitButton = document.getElementById('ctpl_edit_submit');
+		if (!submitButton) {
+			return;
+		}
+
 		submitButton.addEventListener('click', function(evt) {
 			var blocks = {
 			};


### PR DESCRIPTION
fix #21 